### PR TITLE
[PR2] DEV-110 Fixed Connections Table and TabLayout

### DIFF
--- a/src/components/ConnectionsTable/ConnectionList/ConnectionList.tsx
+++ b/src/components/ConnectionsTable/ConnectionList/ConnectionList.tsx
@@ -13,7 +13,7 @@ export const ConnectionList = ({
     enabled = true,
 }: Props) => {
     return (
-        <div className={`${styles.connectionsWrapper} island`}>
+        <div className={`${styles.connectionsWrapper}`}>
             <div className={styles.title}>{title}</div>
             <ul className={styles.connectionsList}>
                 {connections.map((item, index) => {

--- a/src/components/ConnectionsTable/ConnectionsTable.tsx
+++ b/src/components/ConnectionsTable/ConnectionsTable.tsx
@@ -10,7 +10,7 @@ export const ConnectionsTable = () => {
         <div className={styles.wrapper}>
             <ConnectionList
                 title="WebSocket"
-                connections={connections.websocket}
+                connections={[connections.websocket]}
             />
             <ConnectionList
                 title="Boards"

--- a/src/components/FaultsAndWarningLogger/FaultsAndWarningLogger.tsx
+++ b/src/components/FaultsAndWarningLogger/FaultsAndWarningLogger.tsx
@@ -9,7 +9,7 @@ const faultColor = { h: 0, s: 100, l: 40, a: 1 };
 export const FaultsAndWarningLogger = () => {
     const messages = useMessages();
     return (
-        <div className={`${styles.containerMessages} island`}>
+        <div className={`${styles.containerMessages}`}>
             <MessageLogger
                 title={"Warnings"}
                 messages={messages.warning}

--- a/src/layouts/TabLayout/TabItem.ts
+++ b/src/layouts/TabLayout/TabItem.ts
@@ -1,7 +1,7 @@
 export type TabItem = {
-  id: string;
-  name: string;
-  //FIXME: cambiar a obligatorio cuando arregle el bug de aria-hidden
-  icon?: React.ReactNode;
-  component: React.ReactNode;
+    id: string;
+    name: string;
+    //FIXME: cambiar a obligatorio cuando arregle el bug de aria-hidden
+    icon?: React.ReactNode;
+    component: React.ReactNode;
 };

--- a/src/layouts/TabLayout/TabLayout.tsx
+++ b/src/layouts/TabLayout/TabLayout.tsx
@@ -1,15 +1,13 @@
-import { useEffect, useState } from "react";
 import styles from "layouts/TabLayout/TabLayout.module.scss";
 import { TabItem } from "layouts/TabLayout/TabItem";
 import { Header } from "layouts/TabLayout/Header/Header";
-
+import { useTabs } from "./useTabs";
 type Props = {
     items: TabItem[];
 };
 
 export const TabLayout = ({ items }: Props) => {
-    //TODO: fails if item length == 0
-    let [visibleTab, setVisibleTab] = useState(items[0]);
+    const [tabs, visibleTab, setVisibleTab] = useTabs(items);
 
     function handleClick(tab: TabItem) {
         setVisibleTab(tab);
@@ -18,13 +16,13 @@ export const TabLayout = ({ items }: Props) => {
     return (
         <div className={`${styles.tabLayoutWrapper} island`}>
             <Header
-                items={items}
+                items={tabs}
                 visibleTab={visibleTab}
                 handleClick={handleClick}
             />
             <div className={styles.body}>
                 <div className={styles.componentWrapper}>
-                    {items.map((item) => {
+                    {tabs.map((item) => {
                         return (
                             <div
                                 key={item.id}

--- a/src/layouts/TabLayout/useTabs.ts
+++ b/src/layouts/TabLayout/useTabs.ts
@@ -1,0 +1,25 @@
+import { TabItem } from "layouts/TabLayout/TabItem";
+import { useState, useEffect, useMemo } from "react";
+
+function getTabsWithId(tabs: Omit<TabItem, "id">[]): TabItem[] {
+    return tabs.map((element) => {
+        return Object.assign(element, { id: crypto.randomUUID() });
+    });
+}
+
+export function useTabs(
+    items: Omit<TabItem, "id">[]
+): [typeof tabsWithId, typeof visibleTab, typeof setVisibleTab] {
+    const tabsWithId = useMemo(() => {
+        return getTabsWithId(items);
+    }, [getTabsWithId, items]);
+
+    //FIXME: fails if item length == 0
+    const [visibleTab, setVisibleTab] = useState(tabsWithId[0]);
+
+    useEffect(() => {
+        setVisibleTab(tabsWithId[0]);
+    }, [tabsWithId]);
+
+    return [tabsWithId, visibleTab, setVisibleTab];
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,15 +5,27 @@ import "./index.css";
 import { store } from "./store";
 import { Provider } from "react-redux";
 import { WebSocketBrokerProvider } from "services/WebSocketBroker/WebSocketBrokerContext";
-
+import { setWebSocketConnection } from "slices/connectionsSlice";
 const SERVER_URL = `${import.meta.env.VITE_SERVER_IP}:${
     import.meta.env.VITE_SERVER_PORT
 }${import.meta.env.VITE_BACKEND_WEBSOCKET_PATH}`;
 
+function handleSocketOpen() {
+    store.dispatch(setWebSocketConnection(true));
+}
+
+function handleSocketClose() {
+    store.dispatch(setWebSocketConnection(false));
+}
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>
         <Provider store={store}>
-            <WebSocketBrokerProvider url={SERVER_URL}>
+            <WebSocketBrokerProvider
+                url={SERVER_URL}
+                onOpen={handleSocketOpen}
+                onClose={handleSocketClose}
+            >
                 <App />
             </WebSocketBrokerProvider>
         </Provider>

--- a/src/slices/connectionsSlice.ts
+++ b/src/slices/connectionsSlice.ts
@@ -3,19 +3,12 @@ import type { Connection } from "models/Connection";
 const connectionsSlice = createSlice({
     name: "connections",
     initialState: {
-        websocket: [] as Connection[],
+        websocket: { name: "BackendWebSocket", isConnected: false },
         board: [] as Connection[],
-    } as { websocket: Connection[]; board: Connection[] },
+    } as { websocket: Connection; board: Connection[] },
     reducers: {
-        updateWebsocketConnection: (connections, action) => {
-            let conn = connections.websocket.find(
-                (conn) => conn.name == action.payload.name
-            )!;
-            if (conn) {
-                conn.isConnected = action.payload.isConnected;
-            } else {
-                connections.websocket.push(action.payload);
-            }
+        setWebSocketConnection: (connections, action) => {
+            connections.websocket.isConnected = action.payload;
         },
 
         updateBoardConnectionsArray: (
@@ -47,7 +40,7 @@ const connectionsSlice = createSlice({
 });
 
 export const {
-    updateWebsocketConnection,
+    setWebSocketConnection,
     updateBoardConnectionsArray,
     setDisconnectionBoardState,
     initializeMockConnections,


### PR DESCRIPTION
- Updated the `ConnectionsTable` to fit with the new WebSocket architecture.
- Fixed the `TabLayout` ids. The ids that identified each tab where being overwritten with every render. Because of this, the visibleTab id was outdated and so the TabLayout showed nothing because the id didn't match any of the current ones. `useMemo` solves this by returning the same ids for the same input (specified in the dependecy array).