### PR TITLE
[PR 1] DEV-199 allow bigger file sizes

### DIFF
--- a/src/components/BootloaderContainer/Bootloader/useBootloaderState.ts
+++ b/src/components/BootloaderContainer/Bootloader/useBootloaderState.ts
@@ -14,10 +14,10 @@ export function useBootloaderState() {
     );
 
     function upload(board: string, file: File) {
-        file.arrayBuffer().then((arr) => {
+        file.arrayBuffer().then((data) => {
             uploader(
                 board,
-                window.btoa(String.fromCharCode(...new Uint8Array(arr)))
+                window.btoa(Array.from(new Uint8Array(data), (x) => String.fromCodePoint(x)).join(""))
             );
         });
     }


### PR DESCRIPTION
Previously the frontend would crash with files bigger than the variadic argument limit (depends on the implementation, the biggest file I managed to fit was under 1mb). This new way to construct the string recommended in the mozzilla docs solves the issue.

The max size I tested was 21mb, but FW will have a max of around 1mb.